### PR TITLE
Fix/Permission issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ provisioner "remote-exec" {
 	"sudo yum -y localinstall https://yum.puppet.com/puppet6-release-el-7.noarch.rpm",
 	"sudo yum -y install epel-release centos-release-scl-rh",
 	"sudo yum -y update",
-	"echo 0 > /proc/sys/vm/overcommit_memory",
+	"sudo bash -c 'sysctl -w vm.overcommit_memory=0 >> /etc/sysctl.d/vm_overcommit.conf'",
 	"sudo yum -y install katello",
 	"sudo foreman-installer --scenario katello"
 	 ]


### PR DESCRIPTION
Hi,

Permissions should be ok now, however not sure what you were trying to achieve:

Memory overcommit can be disabled by vm.overcommit_memory=2

0 is the default mode, where kernel heuristically determines the allocation by calculating the free memory compared to the allocation request being made. And setting it to 1 enables the wizardry mode, where kernel always advertises that it has enough free memory for any allocation. Setting to 2, means that processes can only allocate up to a configurable amount (overcommit_ratio) of RAM and will start getting allocation failure or OOM messages when it goes beyond that amount.

Is it safe to do so, no. I haven't seen any proper use case where disabling memory overcommit actually helped, unless you are 100% certain of the workload and hardware capacity. In case you are interested, install kernel-docs package and go to /Documentation/sysctl/vm.txt to read more, or read it online.

If you set vm.overcommit_memory=2 then it will overcommit up to the percentage of physical RAM configured in vm.overcommit_ratio (default is 50%).

Fixes #1